### PR TITLE
stop using deprecated DSL request method - plugin2 compatibility

### DIFF
--- a/lib/Dancer2/Plugin/ConditionalCaching.pm
+++ b/lib/Dancer2/Plugin/ConditionalCaching.pm
@@ -47,7 +47,7 @@ register caching => sub {
     my $dsl  = shift;
     my %args = @_;
 
-    my $get_or_head = $dsl->request->method =~ m{^(?:get|head)$}i;
+    my $get_or_head = $dsl->app->request->method =~ m{^(?:get|head)$}i;
 
     my $dry = delete $args{dry} // 0;
 
@@ -82,7 +82,7 @@ register caching => sub {
         }
     }
 
-    my %reqh = HTTP::Headers::Fancy::decode_hash( $dsl->request->headers );
+    my %reqh = HTTP::Headers::Fancy::decode_hash( $dsl->app->request->headers );
 
     my %req_cc = HTTP::Headers::Fancy::split_field_hash( $reqh{CacheControl} );
 


### PR DESCRIPTION
Although this still works it is deprecated and the following should be used instead: `$dsl->app->request`
